### PR TITLE
fix: add additional timezone group check for timezone value

### DIFF
--- a/src/components/TimezoneButton.tsx
+++ b/src/components/TimezoneButton.tsx
@@ -15,6 +15,7 @@ export const TimezoneButton = (props: TimezoneButtonProps): ReactNode => {
 
   const label =
     allTimezones.find((tz) => tz.name === timezone)?.abbreviation ??
+    allTimezones.find((tz) => tz.group.includes(timezone))?.abbreviation ??
     allTimezones.find((tz) => tz.name === currentTimezone)?.abbreviation ??
     allTimezones.find((tz) => tz.group.includes(currentTimezone))?.abbreviation
 


### PR DESCRIPTION
This PR allows providing an `initialValue.timezone` for a richDate field type and showing the correct label for that timezone